### PR TITLE
Emit stat json in compilation assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ module.exports = {
 
 ### `StatsWriterPlugin(opts)`
 * **opts** (`Object`) options
-* **opts.path** (`String`) directory path to create / output to (Default: &quot;&quot;)
 * **opts.filename** (`String`) output file name (Default: &quot;stat.json&quot;)
 * **opts.fields** (`Array`) fields of stats obj to keep (Default: \[&quot;assetsByChunkName&quot;\])
 * **opts.transform** (`Function`) transform function of stats object before writing

--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ module.exports = {
 
     // Write out stats file to build directory.
     new StatsWriterPlugin({
-      path: path.join(__dirname, "build"),
       filename: "stats.json" // Default
     })
   ]

--- a/demo/webpack.config.js
+++ b/demo/webpack.config.js
@@ -17,7 +17,6 @@ module.exports = {
     new StatsWriterPlugin(),
     new StatsWriterPlugin({}),
     new StatsWriterPlugin({
-      path: path.join(__dirname, "build"),
       filename: "stats-transform.json",
       fields: null,
       transform: function (data) {
@@ -25,7 +24,6 @@ module.exports = {
       }
     }),
     new StatsWriterPlugin({
-      path: path.join(__dirname, "build"),
       filename: "stats-custom.json"
     })
   ]

--- a/lib/stats-writer-plugin.js
+++ b/lib/stats-writer-plugin.js
@@ -1,5 +1,3 @@
-var path = require("path");
-
 /**
  * Stats writer module.
  *

--- a/lib/stats-writer-plugin.js
+++ b/lib/stats-writer-plugin.js
@@ -25,7 +25,6 @@ var path = require("path");
  * - https://github.com/webpack/docs/wiki/node.js-api#stats
  *
  * @param {Object}   opts           options
- * @param {String}   opts.path      directory path to create / output to (Default: "")
  * @param {String}   opts.filename  output file name (Default: "stat.json")
  * @param {Array}    opts.fields    fields of stats obj to keep (Default: \["assetsByChunkName"\])
  * @param {Function} opts.transform transform function of stats object before writing
@@ -35,7 +34,6 @@ var path = require("path");
 var StatsWriterPlugin = function (opts) {
   opts = opts || {};
   this.opts = {};
-  this.opts.path = opts.path || "";
   this.opts.filename = opts.filename || "stats.json";
   this.opts.fields = typeof opts.fields !== "undefined" ? opts.fields : ["assetsByChunkName"];
   this.opts.transform = opts.transform || function (data) { return data; };

--- a/lib/stats-writer-plugin.js
+++ b/lib/stats-writer-plugin.js
@@ -43,11 +43,7 @@ var StatsWriterPlugin = function (opts) {
 
 StatsWriterPlugin.prototype.apply = function (compiler) {
   var self = this;
-  compiler.plugin("after-emit", function (curCompiler, callback) {
-    // FS aliases from webpack.
-    var mkdirp = compiler.outputFileSystem.mkdirp;
-    var writeFile = compiler.outputFileSystem.writeFile;
-
+  compiler.plugin("emit", function (curCompiler, callback) {
     // Get stats.
     // **Note**: In future, could pass something like `{ showAssets: true }`
     // to the `getStats()` function for more limited object returned.
@@ -64,17 +60,17 @@ StatsWriterPlugin.prototype.apply = function (compiler) {
     // Transform.
     stats = self.opts.transform(stats);
 
-    // Make directories, write file.
-    mkdirp(self.opts.path, function (err) {
-      if (err) { return callback(err); }
+    var statsJson = JSON.stringify(stats, null, 2);
 
-      writeFile(
-        path.join(self.opts.path, self.opts.filename),
-        JSON.stringify(stats, null, 2),
-        { flags: "w+" },
-        callback
-      );
-    });
+    curCompiler.assets[self.opts.filename] = {
+      source: function () {
+        return statsJson;
+      },
+      size: function () {
+        return statsJson.length;
+      }
+    };
+    callback();
   });
 };
 


### PR DESCRIPTION
Hi, thanks to the project! 

This PR

* Changes `stats.json` output destination from real filesystem to webpack compilation assets.
* Removes `path` option, because it will depend on webpack output path.

It improves support for [webpack-dev-server](https://github.com/webpack/webpack-dev-server) and [webpack-stream](https://github.com/shama/webpack-stream), since these tools does not use real filesystem.

The compilation result of demo project looks like:

```
                       Asset  Size  Chunks             Chunk Names
e49186041feacefb583b.main.js  1613       0  [emitted]  main
                  stats.json    75          [emitted]
        stats-transform.json    44          [emitted]
           stats-custom.json    75          [emitted]
   [0] ./main.js 112 {0} [built]
```

