### PR TITLE
Don't JSON.stringify result of custom transform function by default

### DIFF
--- a/demo/webpack.config.js
+++ b/demo/webpack.config.js
@@ -20,7 +20,17 @@ module.exports = {
       filename: "stats-transform.json",
       fields: null,
       transform: function (data) {
-        return data.assetsByChunkName;
+        return JSON.stringify(data.assetsByChunkName, null, 2);
+      }
+    }),
+    new StatsWriterPlugin({
+      filename: "stats-transform.md",
+      fields: null,
+      transform: function (data) {
+        var assetsByChunkName = data.assetsByChunkName;
+        return Object.keys(assetsByChunkName).reduce(function (acc, key) {
+          return acc += key + " | " + assetsByChunkName[key] + "\n";
+        }, "Name | Asset\n:--- | :----\n");
       }
     }),
     new StatsWriterPlugin({

--- a/lib/stats-writer-plugin.js
+++ b/lib/stats-writer-plugin.js
@@ -37,7 +37,7 @@ var StatsWriterPlugin = function (opts) {
   this.opts = {};
   this.opts.filename = opts.filename || "stats.json";
   this.opts.fields = typeof opts.fields !== "undefined" ? opts.fields : ["assetsByChunkName"];
-  this.opts.transform = opts.transform || function (data) { return data; };
+  this.opts.transform = opts.transform || function (data) { return JSON.stringify(data, null, 2); };
 };
 
 StatsWriterPlugin.prototype.apply = function (compiler) {
@@ -59,14 +59,12 @@ StatsWriterPlugin.prototype.apply = function (compiler) {
     // Transform.
     stats = self.opts.transform(stats);
 
-    var statsJson = JSON.stringify(stats, null, 2);
-
     curCompiler.assets[self.opts.filename] = {
       source: function () {
-        return statsJson;
+        return stats;
       },
       size: function () {
-        return statsJson.length;
+        return stats.length;
       }
     };
     callback();


### PR DESCRIPTION
Hey there. Not sure if this is something you want to add, so feel free to decline if not :wink:

Freeing up the custom transform function like this means we can more easily output other file formats. I've added such an example to the `demo/` so you can see what I mean. I've also maintained the current default transform behaviour of `JSON.stringify`ing a result too.