### PR TITLE
pass compiler to transform callback

### DIFF
--- a/lib/stats-writer-plugin.js
+++ b/lib/stats-writer-plugin.js
@@ -68,7 +68,7 @@ StatsWriterPlugin.prototype.apply = function (compiler) {
     }
 
     // Transform.
-    stats = self.opts.transform(stats);
+    stats = self.opts.transform(stats, curCompiler);
 
     curCompiler.assets[self.opts.filename] = {
       source: function () {


### PR DESCRIPTION
It may be useful – to have access for compiler instance in transform callback.
My case: 
I use this plugin to generate 'template-locals.json' (which used for rendering index.html).
And I want to inline some content from compilation into this file. If compilation param was existed, it would be ease to achieve that. Thank you.