### PR TITLE
Feature/promise support

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,11 @@
 History
 =======
 
+## Unreleased
+
+* Allow `opts.transform` to be a `Promise` as well as a `Function`.
+  [#27](https://github.com/FormidableLabs/webpack-stats-plugin/issues/27)
+
 ## 0.2.0
 
 * **Breaking**: Update to node4+.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,8 +3,10 @@ History
 
 ## Unreleased
 
-* Allow `opts.transform` to be a `Promise` as well as a `Function`.
+* *Feature*: Allow `opts.transform` to be a `Promise` as well as a `Function`.
   [#27](https://github.com/FormidableLabs/webpack-stats-plugin/issues/27)
+* *Bug*: Correctly fail plugin if `opts.transform` throws in webpack4.
+* *Test*: Test errors in all versions of webpack.
 
 ## 0.2.0
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,27 @@ module.exports = {
 }
 ```
 
+### Promise transform
+
+You can use an asynchronous promise to transform as well:
+
+```js
+const StatsWriterPlugin = require("webpack-stats-plugin").StatsWriterPlugin;
+
+module.exports = {
+  plugins: [
+    new StatsWriterPlugin({
+      filename: "stats-transform-promise.json",
+      transform(data) {
+        return Promise.resolve().then(() => JSON.stringify({
+          main: data.assetsByChunkName.main
+        }, null, INDENT));
+      }
+    })
+  ]
+}
+```
+
 ## Plugins
 
 * [`StatsWriterPlugin(opts)`](#statswriterplugin-opts-)
@@ -84,7 +105,7 @@ module.exports = {
 * **opts** (`Object`) options
 * **opts.filename** (`String`) output file name (Default: &quot;stat.json&quot;)
 * **opts.fields** (`Array`) fields of stats obj to keep (Default: \[&quot;assetsByChunkName&quot;\])
-* **opts.transform** (`Function`) transform stats obj (Default: `JSON.stringify()`)
+* **opts.transform** (`Function|Promise`) transform stats obj (Default: `JSON.stringify()`)
 
 Stats writer module.
 

--- a/lib/stats-writer-plugin.js
+++ b/lib/stats-writer-plugin.js
@@ -59,7 +59,7 @@ class StatsWriterPlugin {
 
   apply(compiler) {
     if (compiler.hooks) {
-      compiler.hooks.emit.tap("stats-writer-plugin", this.emitStats.bind(this));
+      compiler.hooks.emit.tapPromise("stats-writer-plugin", this.emitStats.bind(this));
     } else {
       compiler.plugin("emit", this.emitStats.bind(this));
     }
@@ -93,6 +93,7 @@ class StatsWriterPlugin {
       .then((statsStr) => {
         // Handle errors.
         if (err) {
+          curCompiler.errors.push(err);
           if (callback) { return void callback(err); }
           throw err;
         }

--- a/lib/stats-writer-plugin.js
+++ b/lib/stats-writer-plugin.js
@@ -44,7 +44,7 @@ const DEFAULT_TRANSFORM = (data) => JSON.stringify(data, null, INDENT);
  * @param {Object}   opts           options
  * @param {String}   opts.filename  output file name (Default: "stat.json")
  * @param {Array}    opts.fields    fields of stats obj to keep (Default: \["assetsByChunkName"\])
- * @param {Function} opts.transform transform stats obj (Default: `JSON.stringify()`)
+ * @param {Function|Promise} opts.transform transform stats obj (Default: `JSON.stringify()`)
  *
  * @api public
  */
@@ -80,26 +80,35 @@ class StatsWriterPlugin {
     }
 
     // Transform to string.
-    let statsStr;
-    try {
-      statsStr = this.opts.transform(stats, {
+    let err;
+    return Promise.resolve()
+
+      // Transform.
+      .then(() => this.opts.transform(stats, {
         compiler: curCompiler
+      }))
+      .catch((e) => { err = e; })
+
+      // Finish up.
+      .then((statsStr) => {
+        // Handle errors.
+        if (err) {
+          if (callback) { return void callback(err); }
+          throw err;
+        }
+
+        // Add to assets.
+        curCompiler.assets[this.opts.filename] = {
+          source() {
+            return statsStr;
+          },
+          size() {
+            return statsStr.length;
+          }
+        };
+
+        if (callback) { return void callback(); }
       });
-    } catch (err) {
-      if (callback) { return void callback(err); }
-      throw err;
-    }
-
-    curCompiler.assets[this.opts.filename] = {
-      source() {
-        return statsStr;
-      },
-      size() {
-        return statsStr.length;
-      }
-    };
-
-    if (callback) { return void callback(); }
   }
 }
 

--- a/lib/stats-writer-plugin.js
+++ b/lib/stats-writer-plugin.js
@@ -80,9 +80,15 @@ class StatsWriterPlugin {
     }
 
     // Transform to string.
-    const statsStr = this.opts.transform(stats, {
-      compiler: curCompiler
-    });
+    let statsStr;
+    try {
+      statsStr = this.opts.transform(stats, {
+        compiler: curCompiler
+      });
+    } catch (err) {
+      if (callback) { return void callback(err); }
+      throw err;
+    }
 
     curCompiler.assets[this.opts.filename] = {
       source() {
@@ -93,7 +99,7 @@ class StatsWriterPlugin {
       }
     };
 
-    return callback && callback();
+    if (callback) { return void callback(); }
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test": "yarn run test:clean && yarn run test:build && yarn run test:run",
     "test:run": "mocha 'test/**/*.spec.js'",
     "test:clean": "rm -rf test/webpack*/build*",
-    "test:build:single": "cd node_modules/webpack${VERS} && node index.js --config ../../test/webpack${VERS}/webpack.config.js",
+    "test:build:single": "cd node_modules/webpack${VERS} && node index.js --config ../../test/webpack${VERS}/webpack.config${WP_EXTRA}.js",
     "test:build": "builder envs test:build:single '[{\"VERS\":1},{\"VERS\":2},{\"VERS\":3},{\"VERS\":4}]' --buffer",
     "check": "yarn run lint && yarn run test"
   },

--- a/test/expected/build/stats-transform-promise.json
+++ b/test/expected/build/stats-transform-promise.json
@@ -1,0 +1,3 @@
+{
+  "main": "HASH.main.js"
+}

--- a/test/func.spec.js
+++ b/test/func.spec.js
@@ -5,16 +5,29 @@
 /**
  * Functional tests.
  *
+ * ## Builds
+ *
  * Build webpack1-4 to actual files, read those in, and then assert against
  * "expected" fixtures in `test/expected`.
+ *
+ * ## Failures
+ *
+ * Use `builder` to do multi-process executions and assert against the logged
+ * error output.
  */
 const path = require("path");
 const pify = require("pify");
 const fs = pify(require("fs"));
 const expect = require("chai").expect;
+const cp = require("child_process");
+const builderCli = require.resolve("builder/bin/builder");
 
 const BUILD_DIRS = ["build", "build2"];
 const WEBPACKS = [1, 2, 3, 4].map((n) => `webpack${n}`); // eslint-disable-line no-magic-numbers
+
+// Detect if node4 + webpack4 so we can skip.
+const isSkipped = (webpack) => webpack === "webpack4" &&
+  process.version.match(/(v|)([0-9]+)/)[2] === "4"; // eslint-disable-line no-magic-numbers
 
 // Specific hash regex to abstract.
 const HASH_RE = /[0-9a-f]{20}/gm;
@@ -55,31 +68,106 @@ const readBuild = (buildDir) => {
     );
 };
 
-let expecteds;
-const actuals = {};
+// Promise-friendly spawn.
+const spawn = function () {
+  const stdout = [];
+  const stderr = [];
 
-// Read in expected fixtures.
-before(() => readBuild("expected").then((data) => { expecteds = data; }));
+  return new Promise((resolve) => {
+    const proc = cp.spawn.apply(cp, arguments); // eslint-disable-line prefer-spread
+    proc.stdout.on("data", (data) => {
+      stdout.push(data.toString());
+    });
+    proc.stderr.on("data", (data) => {
+      stderr.push(data.toString());
+    });
+    proc.on("close", (code, signal) => resolve({
+      code,
+      signal,
+      stdout: stdout.length ? stdout.join("") : null,
+      stderr: stderr.length ? stderr.join("") : null
+    }));
+  });
+};
 
-// Dynamically create suites and tests.
-WEBPACKS.forEach((webpack) => {
-  before(() => readBuild(webpack).then((data) => { actuals[webpack] = data; }));
+describe("builds", () => {
+  let expecteds;
+  const actuals = {};
 
-  describe(webpack, () => {
-    it("matches expected files", function () {
-      const actual = actuals[webpack];
+  // Read in expected fixtures.
+  before(() => readBuild("expected").then((data) => { expecteds = data; }));
 
-      // Allow webpack4 to have no files if all other webpacks have the right
-      // number of files to account for node4 not being supported.
-      if (webpack === "webpack4" && !actual &&
-          actuals.webpack1 && actuals.webpack2 && actuals.webpack3) {
-        // Dynamically skip.
-        return void this.skip(); // eslint-disable-line no-invalid-this
-      }
+  // Dynamically create suites and tests.
+  WEBPACKS.forEach((webpack) => {
+    before(() => readBuild(webpack).then((data) => { actuals[webpack] = data; }));
 
-      Object.keys(expecteds).forEach((fileKey) => {
-        expect(actual[fileKey], fileKey).to.equal(expecteds[fileKey]);
+    describe(webpack, () => {
+      it("matches expected files", function () {
+        const actual = actuals[webpack];
+
+        // Allow webpack4 to have no files if all other webpacks have the right
+        // number of files to account for node4 not being supported.
+        if (isSkipped(webpack)) {
+          // Dynamically skip.
+          return void this.skip(); // eslint-disable-line no-invalid-this
+        }
+
+        Object.keys(expecteds).forEach((fileKey) => {
+          expect(actual[fileKey], fileKey).to.equal(expecteds[fileKey]);
+        });
       });
     });
   });
+});
+
+describe("failures", () => {
+  // Dynamically figure out if doing webpack4.
+  const VERSIONS = [].concat(
+    [{ VERS: 1 }, { VERS: 2 }, { VERS: 3 }],
+    isSkipped("webpack4") ? [] : [{ VERS: 4 }]
+  );
+  const NUM_ERRS = VERSIONS.length;
+
+  it("fails with synchronous error", () => {
+    // Use builder to concurrently run:
+    // `webpack<VERS> --config test/webpack<VERS>/webpack.config.fail-sync.js`
+    return spawn(builderCli,
+      [
+        "envs", "test:build:single",
+        JSON.stringify(VERSIONS),
+        "--env", JSON.stringify({ WP_EXTRA: ".fail-sync" }),
+        "--buffer", "--bail=false"
+      ]
+    )
+      .then((obj) => {
+        expect(obj.code).to.equal(1);
+        expect(obj.stderr).to.contain(`Hit ${NUM_ERRS} errors`);
+
+        const exps = Array(NUM_ERRS).fill("Error: SYNC");
+        const errs = obj.stderr.match(/(Error\: SYNC)/gm);
+        expect(errs).to.eql(exps);
+      });
+  });
+
+  it("fails with promise rejection", () => {
+    // Use builder to concurrently run:
+    // `webpack<VERS> --config test/webpack<VERS>/webpack.config.fail-promise.js`
+    return spawn(builderCli,
+      [
+        "envs", "test:build:single",
+        JSON.stringify(VERSIONS),
+        "--env", JSON.stringify({ WP_EXTRA: ".fail-promise" }),
+        "--buffer", "--bail=false"
+      ]
+    )
+      .then((obj) => {
+        expect(obj.code).to.equal(1);
+        expect(obj.stderr).to.contain(`Hit ${NUM_ERRS} errors`);
+
+        const exps = Array(NUM_ERRS).fill("Error: PROMISE");
+        const errs = obj.stderr.match(/(Error\: PROMISE)/gm);
+        expect(errs).to.eql(exps);
+      });
+  });
+
 });

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,1 +1,2 @@
 --recursive
+--timeout 10000

--- a/test/webpack1/webpack.config.fail-promise.js
+++ b/test/webpack1/webpack.config.fail-promise.js
@@ -1,0 +1,11 @@
+"use strict";
+
+/**
+ * Fail promise.
+ */
+const base = require("./webpack.config");
+const fail = require("../webpack4/webpack.config.fail-promise");
+
+module.exports = Object.assign({}, base, {
+  plugins: fail.plugins
+});

--- a/test/webpack1/webpack.config.fail-sync.js
+++ b/test/webpack1/webpack.config.fail-sync.js
@@ -1,0 +1,11 @@
+"use strict";
+
+/**
+ * Fail synchronously.
+ */
+const base = require("./webpack.config");
+const fail = require("../webpack4/webpack.config.fail-sync");
+
+module.exports = Object.assign({}, base, {
+  plugins: fail.plugins
+});

--- a/test/webpack2/webpack.config.fail-promise.js
+++ b/test/webpack2/webpack.config.fail-promise.js
@@ -1,0 +1,11 @@
+"use strict";
+
+/**
+ * Fail promise.
+ */
+const base = require("./webpack.config");
+const fail = require("../webpack4/webpack.config.fail-promise");
+
+module.exports = Object.assign({}, base, {
+  plugins: fail.plugins
+});

--- a/test/webpack2/webpack.config.fail-sync.js
+++ b/test/webpack2/webpack.config.fail-sync.js
@@ -1,0 +1,11 @@
+"use strict";
+
+/**
+ * Fail synchronously.
+ */
+const base = require("./webpack.config");
+const fail = require("../webpack4/webpack.config.fail-sync");
+
+module.exports = Object.assign({}, base, {
+  plugins: fail.plugins
+});

--- a/test/webpack3/webpack.config.fail-promise.js
+++ b/test/webpack3/webpack.config.fail-promise.js
@@ -1,0 +1,11 @@
+"use strict";
+
+/**
+ * Fail promise.
+ */
+const base = require("./webpack.config");
+const fail = require("../webpack4/webpack.config.fail-promise");
+
+module.exports = Object.assign({}, base, {
+  plugins: fail.plugins
+});

--- a/test/webpack3/webpack.config.fail-sync.js
+++ b/test/webpack3/webpack.config.fail-sync.js
@@ -1,0 +1,11 @@
+"use strict";
+
+/**
+ * Fail synchronously.
+ */
+const base = require("./webpack.config");
+const fail = require("../webpack4/webpack.config.fail-sync");
+
+module.exports = Object.assign({}, base, {
+  plugins: fail.plugins
+});

--- a/test/webpack4/webpack.config.fail-promise.js
+++ b/test/webpack4/webpack.config.fail-promise.js
@@ -1,0 +1,18 @@
+"use strict";
+
+/**
+ * Fail promise.
+ */
+const base = require("./webpack.config");
+const StatsWriterPlugin = require("../../index").StatsWriterPlugin;
+
+module.exports = Object.assign({}, base, {
+  plugins: [
+    new StatsWriterPlugin({
+      filename: "stats-transform-fail-promise.json",
+      transform() {
+        return Promise.reject(new Error("HI"));
+      }
+    })
+  ]
+});

--- a/test/webpack4/webpack.config.fail-promise.js
+++ b/test/webpack4/webpack.config.fail-promise.js
@@ -11,7 +11,7 @@ module.exports = Object.assign({}, base, {
     new StatsWriterPlugin({
       filename: "stats-transform-fail-promise.json",
       transform() {
-        return Promise.reject(new Error("HI"));
+        return Promise.reject(new Error("PROMISE"));
       }
     })
   ]

--- a/test/webpack4/webpack.config.fail-sync.js
+++ b/test/webpack4/webpack.config.fail-sync.js
@@ -1,0 +1,18 @@
+"use strict";
+
+/**
+ * Fail synchronously.
+ */
+const base = require("./webpack.config");
+const StatsWriterPlugin = require("../../index").StatsWriterPlugin;
+
+module.exports = Object.assign({}, base, {
+  plugins: [
+    new StatsWriterPlugin({
+      filename: "stats-transform-fail-sync.json",
+      transform() {
+        throw new Error("HI");
+      }
+    })
+  ]
+});

--- a/test/webpack4/webpack.config.fail-sync.js
+++ b/test/webpack4/webpack.config.fail-sync.js
@@ -11,7 +11,7 @@ module.exports = Object.assign({}, base, {
     new StatsWriterPlugin({
       filename: "stats-transform-fail-sync.json",
       transform() {
-        throw new Error("HI");
+        throw new Error("SYNC");
       }
     })
   ]

--- a/test/webpack4/webpack.config.js
+++ b/test/webpack4/webpack.config.js
@@ -51,6 +51,20 @@ module.exports = {
     // Relative paths work, but absolute paths do not currently.
     new StatsWriterPlugin({
       filename: "../build2/stats-custom2.json"
+    }),
+    // Promise transform
+    new StatsWriterPlugin({
+      filename: "stats-transform-promise.json",
+      transform(data) {
+        return Promise.resolve()
+          // Force async.
+          .then(() => new Promise((res) => {
+            process.nextTick(res);
+          }))
+          .then(() => JSON.stringify({
+            main: data.assetsByChunkName.main
+          }, null, INDENT));
+      }
     })
   ]
 };


### PR DESCRIPTION
* Allow `opts.transform` to be a `Promise` as well as a `Function`. Fixes #27 
* *Bug*: Correctly fail plugin if `opts.transform` throws in webpack4.
* *Test*: Test errors in all versions of webpack.

/cc @semirturgay -- finally revived this from your original idea in #13 now that we're on node4+ with native `Promise` support.