### PR TITLE
Feature: export the plugin as module.exports, for easier use with webpack-chain

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 const StatsWriterPlugin = require("./lib/stats-writer-plugin");
 
-module.exports = {
-  StatsWriterPlugin
-};
+// exports.StatsWriterPlugin = StatsWriterPlugin
+StatsWriterPlugin.StatsWriterPlugin = StatsWriterPlugin;
+
+module.exports = StatsWriterPlugin;


### PR DESCRIPTION
### The problem

With [webpack-chain](https://github.com/neutrinojs/webpack-chain) , one may use plugins in mutiple ways.

```js
config
  .plugin('your-plugin-0')
    .use(require('your-plugin'))  // require()

  .plugin('your-plugin-1')
    .use(require.resolve('your-plugin')) // absolute path

  .plugin('your-plugin-2')
    .use('your-plugin')  // module name

```

When it comes to `webpack-stats-plugin`, the last two ways break:

```js
config
  .plugin('your-plugin-0')
    .use(
      // require() and resolve the "StatsWriterPlugin" property
      require('webpack.stats-plugin').StatsWriterPlugin
    )

  .plugin('your-plugin-1')
    .use(
      // Won't work, failing to resolve "StatsWriterPlugin" property
      require.resolve('webpack-stats-plugin')
    )

  .plugin('your-plugin-2')
    .use(
      // Won't work, failing to resolve "StatsWriterPlugin" property
      'webpack-stats-plugin'
    )
```

### The cause

In [index.js](https://github.com/FormidableLabs/webpack-stats-plugin/blob/master/index.js#L5), the exported object is as follows:

```js
module.exports = {
  StatsWriterPlugin
};
```

Thus a user may use the plugin as below:

```js
const obj = require('webpack-stats-plugin')
const plugin = imported.StatsWriterPlugin

typeof obj       // object

typeof plugin  // function

obj === plugin // false
```

### The solution

Export the plugin as `module.exports`:

```js
StatsWriterPlugin.StatsWriterPlugin = StatsWriterPlugin;
module.exports = StatsWriterPlugin;
```

A user can use the plugin as below, without breaking backward compatibility.

```js
const obj = require('webpack-stats-plugin')
const plugin = imported.StatsWriterPlugin

typeof obj       // function

typeof plugin  // function

obj === plugin // true
```