### PR TITLE
Add support for cli usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,17 @@ $ yarn add --dev webpack-stats-plugin
 We have example webpack configurations for all versions of webpack. See., e.g.
 [`test/webpack4/webpack.config.js`](test/webpack4/webpack.config.js).
 
+### CLI Usage
+
+You can use this plugin without any `webpack.config.js` configuration to generate all stats directly to `stats.json`.
+
+```bash
+webpack --plugin webpack-stats-plugin
+```
+
 ### Basic
+
+You can also add the plugin to your `webpack.config.js`:
 
 ```js
 const { StatsWriterPlugin } = require("webpack-stats-plugin")

--- a/index.js
+++ b/index.js
@@ -2,6 +2,5 @@
 
 const StatsWriterPlugin = require("./lib/stats-writer-plugin");
 
-module.exports = {
-  StatsWriterPlugin
-};
+module.exports = StatsWriterPlugin;
+module.exports.StatsWriterPlugin = StatsWriterPlugin;


### PR DESCRIPTION
`webpack-cli` allows to run zero-config plugins directly from the command line.

Unfortunately it requires the module to be an unnamed export.  
Therefore I changed the export to support both import strategies - the named import and the unnamed import.

Please let me know what you think :)