### PR TITLE
BUG: Missing `stats` option fields that should be default enabled.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ language: node_js
 node_js:
   - "8"
   - "10"
-  - "11"
+  - "12"
+  - "13"
 
 sudo: false
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,11 @@
 History
 =======
 
+## UNRELEASED
+
+* *Bug*: Fix options issue with `stats` default fields included in output.
+  [#44](https://github.com/FormidableLabs/webpack-stats-plugin/issues/44)
+
 ## 0.3.0
 
 * *Feature*: Add `opts.stats` to pass custom webpack-native [stats](https://webpack.js.org/configuration/stats/#stats) config.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ programmatically refer to the correct bundle path in your Node.js server.
 
 The plugin is available via [npm](https://www.npmjs.com/package/webpack-stats-plugin):
 
-```
+```sh
 $ npm install --save-dev webpack-stats-plugin
 $ yarn add --dev webpack-stats-plugin
 ```
@@ -211,8 +211,6 @@ $ yarn run check
 ## Maintenance Status
 
 **Active:** Formidable is actively working on this project, and we expect to continue for work for the foreseeable future. Bug reports, feature requests and pull requests are welcome.
-
-[yarn workspaces]: https://yarnpkg.com/blog/2017/08/02/introducing-workspaces/
 
 [npm_img]: https://badge.fury.io/js/webpack-stats-plugin.svg
 [npm_site]: http://badge.fury.io/js/webpack-stats-plugin

--- a/lib/stats-writer-plugin.js
+++ b/lib/stats-writer-plugin.js
@@ -80,7 +80,7 @@ class StatsWriterPlugin {
     // Get stats.
     // The second argument automatically skips heavy options (reasons, source, etc)
     // if they are otherwise unspecified.
-    let stats = curCompiler.getStats().toJson(this.opts.stats, "forToString");
+    let stats = curCompiler.getStats().toJson(this.opts.stats);
 
     // Filter to fields.
     if (this.opts.fields) {

--- a/test/expected/build/stats-custom-stats-fields.json
+++ b/test/expected/build/stats-custom-stats-fields.json
@@ -61,5 +61,17 @@
       "chunkNames": []
     }
   ],
-  "publicPath": "/website-o-doom/"
+  "publicPath": "/website-o-doom/",
+  "namedChunkGroups": {
+    "main": {
+      "chunks": [
+        "main"
+      ],
+      "assets": [
+        "6416defbb3d8d2a6987b.main.js"
+      ],
+      "children": {},
+      "childAssets": {}
+    }
+  }
 }

--- a/test/expected/build/stats-custom-stats-fields.json
+++ b/test/expected/build/stats-custom-stats-fields.json
@@ -1,5 +1,64 @@
 {
   "errors": [],
   "warnings": [],
-  "assets": []
+  "assets": [
+    {
+      "name": "6416defbb3d8d2a6987b.main.js",
+      "size": 3947,
+      "chunks": [
+        "main"
+      ],
+      "chunkNames": [
+        "main"
+      ]
+    },
+    {
+      "name": "stats.json",
+      "size": 75,
+      "chunks": [],
+      "chunkNames": []
+    },
+    {
+      "name": "stats-transform.json",
+      "size": 44,
+      "chunks": [],
+      "chunkNames": []
+    },
+    {
+      "name": "stats-transform.md",
+      "size": 62,
+      "chunks": [],
+      "chunkNames": []
+    },
+    {
+      "name": "stats-transform-custom-obj.json",
+      "size": 44,
+      "chunks": [],
+      "chunkNames": []
+    },
+    {
+      "name": "stats-custom.json",
+      "size": 75,
+      "chunks": [],
+      "chunkNames": []
+    },
+    {
+      "name": "../build2/stats-custom2.json",
+      "size": 75,
+      "chunks": [],
+      "chunkNames": []
+    },
+    {
+      "name": "stats-transform-promise.json",
+      "size": 44,
+      "chunks": [],
+      "chunkNames": []
+    },
+    {
+      "name": "stats-custom-stats.json",
+      "size": 125,
+      "chunks": [],
+      "chunkNames": []
+    }
+  ]
 }

--- a/test/expected/build/stats-custom-stats-fields.json
+++ b/test/expected/build/stats-custom-stats-fields.json
@@ -61,6 +61,7 @@
       "chunkNames": []
     }
   ],
+  "hash": "6416defbb3d8d2a6987b",
   "publicPath": "/website-o-doom/",
   "namedChunkGroups": {
     "main": {

--- a/test/expected/build/stats-custom-stats-fields.json
+++ b/test/expected/build/stats-custom-stats-fields.json
@@ -60,5 +60,6 @@
       "chunks": [],
       "chunkNames": []
     }
-  ]
+  ],
+  "publicPath": "/website-o-doom/"
 }

--- a/test/webpack1/webpack.config.fail-promise.js
+++ b/test/webpack1/webpack.config.fail-promise.js
@@ -6,6 +6,7 @@
 const base = require("./webpack.config");
 const fail = require("../webpack4/webpack.config.fail-promise");
 
-module.exports = Object.assign({}, base, {
+module.exports = {
+  ...base,
   plugins: fail.plugins
-});
+};

--- a/test/webpack1/webpack.config.fail-sync.js
+++ b/test/webpack1/webpack.config.fail-sync.js
@@ -6,6 +6,7 @@
 const base = require("./webpack.config");
 const fail = require("../webpack4/webpack.config.fail-sync");
 
-module.exports = Object.assign({}, base, {
+module.exports = {
+  ...base,
   plugins: fail.plugins
-});
+};

--- a/test/webpack1/webpack.config.js
+++ b/test/webpack1/webpack.config.js
@@ -4,7 +4,8 @@
  * Webpack configuration
  */
 const path = require("path");
-const { mode, ...base } = require("../webpack4/webpack.config");
+const base = require("../webpack4/webpack.config");
+delete base.mode;
 
 module.exports = {
   ...base,

--- a/test/webpack1/webpack.config.js
+++ b/test/webpack1/webpack.config.js
@@ -4,15 +4,14 @@
  * Webpack configuration
  */
 const path = require("path");
-const base = require("../webpack4/webpack.config");
+const { mode, ...base } = require("../webpack4/webpack.config");
 
 module.exports = {
+  ...base,
   cache: true,
   context: __dirname,
-  entry: "../src/main.js",
   output: {
-    path: path.join(__dirname, "build"),
-    filename: "[hash].main.js"
-  },
-  plugins: base.plugins // use plugins from webpack4
+    ...base.output,
+    path: path.join(__dirname, "build")
+  }
 };

--- a/test/webpack2/webpack.config.fail-promise.js
+++ b/test/webpack2/webpack.config.fail-promise.js
@@ -6,6 +6,7 @@
 const base = require("./webpack.config");
 const fail = require("../webpack4/webpack.config.fail-promise");
 
-module.exports = Object.assign({}, base, {
+module.exports = {
+  ...base,
   plugins: fail.plugins
-});
+};

--- a/test/webpack2/webpack.config.fail-sync.js
+++ b/test/webpack2/webpack.config.fail-sync.js
@@ -6,6 +6,7 @@
 const base = require("./webpack.config");
 const fail = require("../webpack4/webpack.config.fail-sync");
 
-module.exports = Object.assign({}, base, {
+module.exports = {
+  ...base,
   plugins: fail.plugins
-});
+};

--- a/test/webpack2/webpack.config.js
+++ b/test/webpack2/webpack.config.js
@@ -4,10 +4,12 @@ const path = require("path");
 const base = require("../webpack1/webpack.config");
 
 // Reuse webpack1
-module.exports = Object.assign({}, base, {
+module.exports = {
+  ...base,
   context: __dirname,
   output: {
-    path: path.join(__dirname, "build"),
-    filename: "[hash].main.js"
+    ...base.output,
+    path: path.join(__dirname, "build")
   }
-});
+};
+

--- a/test/webpack3/webpack.config.fail-promise.js
+++ b/test/webpack3/webpack.config.fail-promise.js
@@ -6,6 +6,7 @@
 const base = require("./webpack.config");
 const fail = require("../webpack4/webpack.config.fail-promise");
 
-module.exports = Object.assign({}, base, {
+module.exports = {
+  ...base,
   plugins: fail.plugins
-});
+};

--- a/test/webpack3/webpack.config.fail-sync.js
+++ b/test/webpack3/webpack.config.fail-sync.js
@@ -6,6 +6,7 @@
 const base = require("./webpack.config");
 const fail = require("../webpack4/webpack.config.fail-sync");
 
-module.exports = Object.assign({}, base, {
+module.exports = {
+  ...base,
   plugins: fail.plugins
-});
+};

--- a/test/webpack3/webpack.config.js
+++ b/test/webpack3/webpack.config.js
@@ -4,10 +4,11 @@ const path = require("path");
 const base = require("../webpack1/webpack.config");
 
 // Reuse webpack1
-module.exports = Object.assign({}, base, {
+module.exports = {
+  ...base,
   context: __dirname,
   output: {
-    path: path.join(__dirname, "build"),
-    filename: "[hash].main.js"
+    ...base.output,
+    path: path.join(__dirname, "build")
   }
-});
+};

--- a/test/webpack4/webpack.config.fail-promise.js
+++ b/test/webpack4/webpack.config.fail-promise.js
@@ -6,7 +6,8 @@
 const base = require("./webpack.config");
 const { StatsWriterPlugin } = require("../../index");
 
-module.exports = Object.assign({}, base, {
+module.exports = {
+  ...base,
   plugins: [
     new StatsWriterPlugin({
       filename: "stats-transform-fail-promise.json",
@@ -15,4 +16,4 @@ module.exports = Object.assign({}, base, {
       }
     })
   ]
-});
+};

--- a/test/webpack4/webpack.config.fail-sync.js
+++ b/test/webpack4/webpack.config.fail-sync.js
@@ -6,7 +6,8 @@
 const base = require("./webpack.config");
 const { StatsWriterPlugin } = require("../../index");
 
-module.exports = Object.assign({}, base, {
+module.exports = {
+  ...base,
   plugins: [
     new StatsWriterPlugin({
       filename: "stats-transform-fail-sync.json",
@@ -15,4 +16,4 @@ module.exports = Object.assign({}, base, {
       }
     })
   ]
-});
+};

--- a/test/webpack4/webpack.config.js
+++ b/test/webpack4/webpack.config.js
@@ -31,6 +31,7 @@ module.exports = {
   entry: "../src/main.js",
   output: {
     path: path.join(__dirname, "build"),
+    publicPath: "/website-o-doom/",
     filename: "[hash].main.js"
   },
   devtool: false,
@@ -98,10 +99,7 @@ module.exports = {
     }),
     new StatsWriterPlugin({
       filename: "stats-custom-stats-fields.json",
-      fields: ["errors", "warnings", "assets"],
-      stats: Object.assign({}, STAT_RESET, {
-        assets: true
-      })
+      fields: ["errors", "warnings", "assets", "publicPath"]
     }),
     new StatsWriterPlugin({
       filename: "stats-override-tostring-opt.json",

--- a/test/webpack4/webpack.config.js
+++ b/test/webpack4/webpack.config.js
@@ -11,6 +11,7 @@ const STAT_RESET = Object.freeze({
   all: false,
   // explicitly turn off older fields
   // (webpack <= v2.7.0 does not support "all")
+  // See: https://webpack.js.org/configuration/stats/
   performance: false,
   hash: false,
   version: false,
@@ -22,7 +23,9 @@ const STAT_RESET = Object.freeze({
   cachedAssets: false,
   children: false,
   moduleTrace: false,
-  assets: false
+  assets: false,
+  modules: false,
+  publicPath: false
 });
 
 module.exports = {
@@ -99,7 +102,7 @@ module.exports = {
     }),
     new StatsWriterPlugin({
       filename: "stats-custom-stats-fields.json",
-      fields: ["errors", "warnings", "assets", "publicPath"]
+      fields: ["errors", "warnings", "assets"] // TODO: , "publicPath"
     }),
     new StatsWriterPlugin({
       filename: "stats-override-tostring-opt.json",

--- a/test/webpack4/webpack.config.js
+++ b/test/webpack4/webpack.config.js
@@ -104,7 +104,7 @@ module.exports = {
     // https://github.com/FormidableLabs/webpack-stats-plugin/issues/44
     new StatsWriterPlugin({
       filename: "stats-custom-stats-fields.json",
-      fields: ["errors", "warnings", "assets", "publicPath", "namedChunkGroups"]
+      fields: ["errors", "warnings", "assets", "hash", "publicPath", "namedChunkGroups"]
     }),
     new StatsWriterPlugin({
       filename: "stats-override-tostring-opt.json",

--- a/test/webpack4/webpack.config.js
+++ b/test/webpack4/webpack.config.js
@@ -104,7 +104,7 @@ module.exports = {
     // https://github.com/FormidableLabs/webpack-stats-plugin/issues/44
     new StatsWriterPlugin({
       filename: "stats-custom-stats-fields.json",
-      fields: ["errors", "warnings", "assets", "publicPath"]
+      fields: ["errors", "warnings", "assets", "publicPath", "namedChunkGroups"]
     }),
     new StatsWriterPlugin({
       filename: "stats-override-tostring-opt.json",

--- a/test/webpack4/webpack.config.js
+++ b/test/webpack4/webpack.config.js
@@ -100,9 +100,11 @@ module.exports = {
         return JSON.stringify(data, null, INDENT);
       }
     }),
+    // Regression test: Missing `stats` option fields that should be default enabled.
+    // https://github.com/FormidableLabs/webpack-stats-plugin/issues/44
     new StatsWriterPlugin({
       filename: "stats-custom-stats-fields.json",
-      fields: ["errors", "warnings", "assets"] // TODO: , "publicPath"
+      fields: ["errors", "warnings", "assets", "publicPath"]
     }),
     new StatsWriterPlugin({
       filename: "stats-override-tostring-opt.json",


### PR DESCRIPTION
- Add regression test and bugfix for issue wherein expected default `stats` options aren't enabled. Fixes #44 
- Modernize some of our test / config code.
- Minor documentation fixes.
- Add more nodes to Travis.

/cc @elsassph 