### PR TITLE
Chore: update to new webpack5 hooks APIs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,9 @@ Stats can be a string or array (we'll have an array due to source maps):
 },
 ```
 
-**Note**: The stats object is **big**. It includes the entire source included in a bundle. Thus, we default `opts.fields` to `["assetsByChunkName"]` to only include those. However, if you want the _whole thing_ (maybe doing an `opts.transform` function), then you can set `fields: null` in options to get **all** of the stats object.
+**`fields`, `stats`**
+
+The stats object is **big**. It includes the entire source included in a bundle. Thus, we default `opts.fields` to `["assetsByChunkName"]` to only include those. However, if you want the _whole thing_ (maybe doing an `opts.transform` function), then you can set `fields: null` in options to get **all** of the stats object.
 
 You may also pass a custom stats config object (or string preset) via `opts.stats` in order to select exactly what you want added to the data passed to the transform. When `opts.stats` is passed, `opts.fields` will default to `null`.
 
@@ -157,11 +159,21 @@ See:
 - https://webpack.js.org/configuration/stats/#stats
 - https://webpack.js.org/api/node/#stats-object
 
-**`filename`**: The `opts.filename` option can be a file name or path relative to `output.path` in webpack configuration. It should not be absolute. It may also be a function, in which case it will be passed the current compiler instance and expected to return a filename to use.
+**`filename`**
 
-**`transform`**: By default, the retrieved stats object is `JSON.stringify`'ed but by supplying an alternate transform you can target _any_ output format. See [`test/scenarios/webpack5/webpack.config.js`](test/scenarios/webpack5/webpack.config.js) for various examples including Markdown output.
+The `opts.filename` option can be a file name or path relative to `output.path` in webpack configuration. It should not be absolute. It may also be a function, in which case it will be passed the current compiler instance and expected to return a filename to use.
+
+**`transform`**
+
+By default, the retrieved stats object is `JSON.stringify`'ed but by supplying an alternate transform you can target _any_ output format. See [`test/scenarios/webpack5/webpack.config.js`](test/scenarios/webpack5/webpack.config.js) for various examples including Markdown output.
 
 - **Warning**: The output of `transform` should be a `String`, not an object. On Node `v4.x` if you return a real object in `transform`, then webpack will break with a `TypeError` (See [#8](https://github.com/FormidableLabs/webpack-stats-plugin/issues/8)). Just adding a simple `JSON.stringify()` around your object is usually what you need to solve any problems.
+
+**Internal notes**
+
+In modern webpack, the plugin uses the [`processAssets`](https://webpack.js.org/api/compilation-hooks/#processassets) compilation hook if available when adding the stats object file to the overall compilation to write out along with all the other webpack-built assets. This is the [last possible place](https://github.com/webpack/webpack/blob/f2f998b58362d5edc9945a48f8245a3347ad007c/lib/Compilation.js#L2000-L2007) to hook in before the compilation is frozen in future webpack releases.
+
+In earlier webpack, the plugin uses the much later [`emit`](https://webpack.js.org/api/compiler-hooks/#emit) compiler hook. There are technically some assets/stats data that could be added after `processAssets` and before `emit`, but for most practical uses of this plugin users shouldn't see any differences in the usable data produced by different versions of webpack.
 
 ## Contributions
 

--- a/lib/stats-writer-plugin.js
+++ b/lib/stats-writer-plugin.js
@@ -73,10 +73,8 @@ class StatsWriterPlugin {
   apply(compiler) {
     if (compiler.hooks) {
       compiler.hooks.compilation.tap("stats-writer-plugin", (compilation) => {
-        if (compilation.emitAsset && compilation.hooks.processAssets) {
-          // Modern.
-          console.log("TODO MODERN");
-          this.emitAsset = compilation.emitAsset.bind(compilation);
+        if (compilation.hooks.processAssets) {
+          // Modern: `processAssets` is one of the last hooks before frozen assets.
           compilation.hooks.processAssets.tapPromise(
             {
               name: "stats-writer-plugin",
@@ -85,14 +83,12 @@ class StatsWriterPlugin {
             () => this.emitStats(compilation)
           );
         } else {
-          // Legacy
-          console.log("TODO LEGACY");
+          // Legacy.
           compiler.hooks.emit.tapPromise("stats-writer-plugin", this.emitStats.bind(this));
         }
       });
     } else {
-      // Super-legacy
-      console.log("TODO SUPER-LEGACY");
+      // Super-legacy.
       compiler.plugin("emit", this.emitStats.bind(this));
     }
   }
@@ -147,9 +143,9 @@ class StatsWriterPlugin {
           : this.opts.filename;
 
         // Add to assets.
-        if (this.emitAsset) {
-          // Modern bound method.
-          this.emitAsset(filename, source);
+        if (curCompiler.emitAsset) {
+          // Modern method.
+          curCompiler.emitAsset(filename, source);
         } else {
           // Fallback to deprecated method.
           curCompiler.assets[filename] = source;

--- a/lib/stats-writer-plugin.js
+++ b/lib/stats-writer-plugin.js
@@ -75,10 +75,11 @@ class StatsWriterPlugin {
       compiler.hooks.compilation.tap("stats-writer-plugin", (compilation) => {
         if (compilation.hooks.processAssets) {
           // Modern: `processAssets` is one of the last hooks before frozen assets.
+          // See: https://webpack.js.org/api/compilation-hooks/#processassets
           compilation.hooks.processAssets.tapPromise(
             {
               name: "stats-writer-plugin",
-              stage: compilation.PROCESS_ASSETS_STAGE_DERIVED
+              stage: compilation.constructor.PROCESS_ASSETS_STAGE_SUMMARIZE
             },
             () => this.emitStats(compilation)
           );

--- a/lib/stats-writer-plugin.js
+++ b/lib/stats-writer-plugin.js
@@ -72,8 +72,27 @@ class StatsWriterPlugin {
 
   apply(compiler) {
     if (compiler.hooks) {
-      compiler.hooks.emit.tapPromise("stats-writer-plugin", this.emitStats.bind(this));
+      compiler.hooks.compilation.tap("stats-writer-plugin", (compilation) => {
+        if (compilation.emitAsset && compilation.hooks.processAssets) {
+          // Modern.
+          console.log("TODO MODERN");
+          this.emitAsset = compilation.emitAsset.bind(compilation);
+          compilation.hooks.processAssets.tapPromise(
+            {
+              name: "stats-writer-plugin",
+              stage: compilation.PROCESS_ASSETS_STAGE_DERIVED
+            },
+            () => this.emitStats(compilation)
+          );
+        } else {
+          // Legacy
+          console.log("TODO LEGACY");
+          compiler.hooks.emit.tapPromise("stats-writer-plugin", this.emitStats.bind(this));
+        }
+      });
     } else {
+      // Super-legacy
+      console.log("TODO SUPER-LEGACY");
       compiler.plugin("emit", this.emitStats.bind(this));
     }
   }
@@ -104,6 +123,17 @@ class StatsWriterPlugin {
 
       // Finish up.
       .then((statsStr) => {
+        // Create simple equivalent of RawSource from webpack-sources.
+        const statsBuf = Buffer.from(statsStr || "", "utf-8");
+        const source = {
+          source() {
+            return statsBuf;
+          },
+          size() {
+            return statsBuf.length;
+          }
+        };
+
         // Handle errors.
         if (err) {
           curCompiler.errors.push(err);
@@ -117,14 +147,13 @@ class StatsWriterPlugin {
           : this.opts.filename;
 
         // Add to assets.
-        curCompiler.assets[filename] = {
-          source() {
-            return statsStr;
-          },
-          size() {
-            return statsStr.length;
-          }
-        };
+        if (this.emitAsset) {
+          // Modern bound method.
+          this.emitAsset(filename, source);
+        } else {
+          // Fallback to deprecated method.
+          curCompiler.assets[filename] = source;
+        }
 
         // eslint-disable-next-line promise/no-callback-in-promise,promise/always-return
         if (callback) { return void callback(); }

--- a/test/func.spec.js
+++ b/test/func.spec.js
@@ -218,7 +218,7 @@ describe("failures", function () {
     expect(obj.stderr).to.contain(`Hit ${NUM_ERRS} errors`);
 
     const exps = Array(NUM_ERRS).fill("Error: SYNC");
-    const errs = obj.stderr.match(/(Error\: SYNC)/gm);
+    const errs = obj.stderr.match(/(^Error\: SYNC)/gm);
     expect(errs).to.eql(exps);
   });
 
@@ -237,7 +237,7 @@ describe("failures", function () {
     expect(obj.stderr).to.contain(`Hit ${NUM_ERRS} errors`);
 
     const exps = Array(NUM_ERRS).fill("Error: PROMISE");
-    const errs = obj.stderr.match(/(Error\: PROMISE)/gm);
+    const errs = obj.stderr.match(/(^Error\: PROMISE)/gm);
     expect(errs).to.eql(exps);
   });
 });


### PR DESCRIPTION
- Use non-deprecated hooks / methods of adding assets. Fixes #52 
- Update tests for webpack5 expected failures