### PR TITLE
Bugfixes for new webpack5 integration

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,11 @@
 History
 =======
 
+## UNRELEASED
+
+* *Bug*: Fix multiple stats output issue.
+  [#57](https://github.com/FormidableLabs/webpack-stats-plugin/issues/57)
+
 ## 1.0.0
 
 * *Feature*: Support `webpack@5`.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,7 +4,10 @@ History
 ## UNRELEASED
 
 * *Bug*: Fix multiple stats output issue.
+  [#55](https://github.com/FormidableLabs/webpack-stats-plugin/issues/55)
   [#57](https://github.com/FormidableLabs/webpack-stats-plugin/issues/57)
+* *Bug*: Change `processAssets` hook stage to `PROCESS_ASSETS_STAGE_REPORT` to correctly get hashed asset names.
+  [#56](https://github.com/FormidableLabs/webpack-stats-plugin/issues/56)
 
 ## 1.0.0
 

--- a/lib/stats-writer-plugin.js
+++ b/lib/stats-writer-plugin.js
@@ -72,7 +72,7 @@ class StatsWriterPlugin {
 
   apply(compiler) {
     if (compiler.hooks) {
-      compiler.hooks.compilation.tap("stats-writer-plugin", (compilation) => {
+      compiler.hooks.thisCompilation.tap("stats-writer-plugin", (compilation) => {
         if (compilation.hooks.processAssets) {
           // Modern: `processAssets` is one of the last hooks before frozen assets.
           // See: https://webpack.js.org/api/compilation-hooks/#processassets

--- a/lib/stats-writer-plugin.js
+++ b/lib/stats-writer-plugin.js
@@ -75,11 +75,16 @@ class StatsWriterPlugin {
       compiler.hooks.thisCompilation.tap("stats-writer-plugin", (compilation) => {
         if (compilation.hooks.processAssets) {
           // Modern: `processAssets` is one of the last hooks before frozen assets.
-          // See: https://webpack.js.org/api/compilation-hooks/#processassets
+          // We choose `PROCESS_ASSETS_STAGE_REPORT` which is the last possible
+          // stage after which to emit.
+          //
+          // See:
+          // - https://webpack.js.org/api/compilation-hooks/#processassets
+          // - https://github.com/FormidableLabs/webpack-stats-plugin/issues/56
           compilation.hooks.processAssets.tapPromise(
             {
               name: "stats-writer-plugin",
-              stage: compilation.constructor.PROCESS_ASSETS_STAGE_SUMMARIZE
+              stage: compilation.constructor.PROCESS_ASSETS_STAGE_REPORT
             },
             () => this.emitStats(compilation)
           );

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "test:run": "mocha 'test/**/*.spec.js'",
     "test:clean": "rm -rf test/scenarios/webpack*/build*",
     "test:build:single": "node node_modules/webpack${VERS}/index.js --config test/scenarios/webpack${VERS}/webpack.config${WP_EXTRA}.js",
-    "test:build": "builder envs test:build:single '[{\"VERS\":1},{\"VERS\":2},{\"VERS\":3},{\"VERS\":4},{\"VERS\":5}]' --buffer",
+    "test:build": "builder envs test:build:single '[{\"VERS\":1},{\"VERS\":2},{\"VERS\":3},{\"VERS\":4},{\"VERS\":5},{\"VERS\":5,\"WP_EXTRA\":\".contenthash\"}]' --buffer",
     "check": "yarn run lint && yarn run test"
   },
   "dependencies": {},

--- a/test/scenarios/webpack5/webpack.config.contenthash.js
+++ b/test/scenarios/webpack5/webpack.config.contenthash.js
@@ -1,0 +1,43 @@
+
+
+"use strict";
+
+/**
+ * Regression test for: https://github.com/FormidableLabs/webpack-stats-plugin/issues/56
+ */
+const path = require("path");
+const { StatsWriterPlugin } = require("../../../index");
+
+module.exports = {
+  mode: "production",
+  context: __dirname,
+  entry: {
+    main: "../../src/main.js"
+  },
+  output: {
+    path: path.join(__dirname, "build"),
+    publicPath: "/website-o-doom/",
+    filename: "contenthash.[contenthash].main.js"
+  },
+  devtool: false,
+  plugins: [
+    new StatsWriterPlugin({
+      filename: "stats-contenthash.json",
+      fields: ["entrypoints"]
+    })
+  ],
+  optimization: {
+    splitChunks: {
+      cacheGroups: {
+        vendors: {
+          priority: -10,
+          test: /[\\/]node_modules[\\/]/
+        }
+      },
+      chunks: "async",
+      minChunks: 1,
+      minSize: 30000,
+      name: false
+    }
+  }
+};


### PR DESCRIPTION
## Work
- Switch from `compilation` to `thisCompilation` hook to capture compilation for later use. Fixes #57, fixes #55 
- Switch `processAssets` stage from `PROCESS_ASSETS_STAGE_SUMMARIZE` to `PROCESS_ASSETS_STAGE_REPORT`. Fixes #56 

## Work for later
- [ ] Add regression test for child / multiple compilation outputs. (Maybe via a custom plugin that taps into something like https://github.com/webpack-contrib/mini-css-extract-plugin/blob/master/src/loader.js#L140)