### PR TITLE
Bug: Update existing assets and only set hooks once.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,11 @@
 History
 =======
 
+## UNRELEASED
+
+* *Bug*: Fix multiple stats output with `webpack --watch`.
+  [#59](https://github.com/FormidableLabs/webpack-stats-plugin/issues/59)
+
 ## 1.0.1
 
 * *Bug*: Fix multiple stats output issue.

--- a/lib/stats-writer-plugin.js
+++ b/lib/stats-writer-plugin.js
@@ -3,17 +3,6 @@
 const INDENT = 2;
 const DEFAULT_TRANSFORM = (data) => JSON.stringify(data, null, INDENT);
 
-// Helper to call a function only once.
-const once = function (fn) {
-  let called = false;
-  return (...args) => {
-    if (!called) {
-      called = true;
-      fn(...args);
-    }
-  };
-};
-
 /**
  * Stats writer module.
  *
@@ -83,8 +72,10 @@ class StatsWriterPlugin {
 
   apply(compiler) {
     if (compiler.hooks) {
-      // Capture the compilation once and then set up further hooks.
-      compiler.hooks.thisCompilation.tap("stats-writer-plugin", once((compilation) => {
+      let emitHookSet = false;
+
+      // Capture the compilation and then set up further hooks.
+      compiler.hooks.thisCompilation.tap("stats-writer-plugin", (compilation) => {
         if (compilation.hooks.processAssets) {
           // Modern: `processAssets` is one of the last hooks before frozen assets.
           // We choose `PROCESS_ASSETS_STAGE_REPORT` which is the last possible
@@ -100,11 +91,17 @@ class StatsWriterPlugin {
             },
             () => this.emitStats(compilation)
           );
-        } else {
+        } else if (!emitHookSet) {
           // Legacy.
+          //
+          // Set up the `compiler` level hook only once to avoid multiple
+          // calls during `webpack --watch`. (We have to do this here because
+          // we can't otherwise detect if `compilation.hooks.processAssets` is
+          // available for modern mode.)
+          emitHookSet = true;
           compiler.hooks.emit.tapPromise("stats-writer-plugin", this.emitStats.bind(this));
         }
-      }));
+      });
     } else {
       // Super-legacy.
       compiler.plugin("emit", this.emitStats.bind(this));

--- a/lib/stats-writer-plugin.js
+++ b/lib/stats-writer-plugin.js
@@ -3,6 +3,17 @@
 const INDENT = 2;
 const DEFAULT_TRANSFORM = (data) => JSON.stringify(data, null, INDENT);
 
+// Helper to call a function only once.
+const once = function (fn) {
+  let called = false;
+  return (...args) => {
+    if (!called) {
+      called = true;
+      fn(...args);
+    }
+  };
+};
+
 /**
  * Stats writer module.
  *
@@ -72,7 +83,8 @@ class StatsWriterPlugin {
 
   apply(compiler) {
     if (compiler.hooks) {
-      compiler.hooks.thisCompilation.tap("stats-writer-plugin", (compilation) => {
+      // Capture the compilation once and then set up further hooks.
+      compiler.hooks.thisCompilation.tap("stats-writer-plugin", once((compilation) => {
         if (compilation.hooks.processAssets) {
           // Modern: `processAssets` is one of the last hooks before frozen assets.
           // We choose `PROCESS_ASSETS_STAGE_REPORT` which is the last possible
@@ -92,7 +104,7 @@ class StatsWriterPlugin {
           // Legacy.
           compiler.hooks.emit.tapPromise("stats-writer-plugin", this.emitStats.bind(this));
         }
-      });
+      }));
     } else {
       // Super-legacy.
       compiler.plugin("emit", this.emitStats.bind(this));
@@ -124,6 +136,7 @@ class StatsWriterPlugin {
       .catch((e) => { err = e; })
 
       // Finish up.
+      // eslint-disable-next-line max-statements
       .then((statsStr) => {
         // Create simple equivalent of RawSource from webpack-sources.
         const statsBuf = Buffer.from(statsStr || "", "utf-8");
@@ -151,7 +164,12 @@ class StatsWriterPlugin {
         // Add to assets.
         if (curCompiler.emitAsset) {
           // Modern method.
-          curCompiler.emitAsset(filename, source);
+          const asset = curCompiler.getAsset(filename);
+          if (asset) {
+            curCompiler.updateAsset(filename, source);
+          } else {
+            curCompiler.emitAsset(filename, source);
+          }
         } else {
           // Fallback to deprecated method.
           curCompiler.assets[filename] = source;


### PR DESCRIPTION
* Only call `compiler.hooks.emit.tapPromise("stats-writer-plugin")` once for legacy mode hooks. Fixes #59 
* Check if asset exists and either emits or updates accordingly.

@evilebottnawi -- Thanks for your guidance again! Mind seeing if my `once()` wrapper to only set hooks once after capturing `thisCompilation` works? I noticed this avoids the situation of the stats file _itself_ ending up in the `compilation` which is what I think we want, but would love a second opinion!

@jdelStrother -- Mind giving this branch a whirl and see if it fixes your problem and otherwise behaves like you would expect?