### PR TITLE
Support readable stream

### DIFF
--- a/lib/stats-writer-plugin.js
+++ b/lib/stats-writer-plugin.js
@@ -160,6 +160,10 @@ class StatsWriterPlugin {
         if (isReadableStream(statsStr)) {
           const writeStream = fs.createWriteStream(path.join(stats.outputPath, filename));
           statsStr.pipe(writeStream);
+          if (callback) {
+            // eslint-disable-next-line promise/no-callback-in-promise
+            statsStr.on("close", () => callback());
+          }
           return;
         }
 

--- a/lib/stats-writer-plugin.js
+++ b/lib/stats-writer-plugin.js
@@ -159,8 +159,7 @@ class StatsWriterPlugin {
 
         if (isReadableStream(statsStr)) {
           const writeStream = fs.createWriteStream(path.join(stats.outputPath, filename));
-          statsStr.on("data", (chunk) => writeStream.write(chunk));
-          statsStr.on("end", () => writeStream.end());
+          statsStr.pipe(writeStream);
           return;
         }
 

--- a/lib/stats-writer-plugin.js
+++ b/lib/stats-writer-plugin.js
@@ -1,7 +1,17 @@
 "use strict";
 
+const fs = require("fs");
+const path = require("path");
+
 const INDENT = 2;
 const DEFAULT_TRANSFORM = (data) => JSON.stringify(data, null, INDENT);
+
+const isReadableStream = (value) => typeof value.read === "function"
+  && typeof value.pause === "function"
+  && typeof value.resume === "function"
+  && typeof value.pipe === "function"
+  && typeof value.once === "function"
+  && typeof value.removeListener === "function";
 
 /**
  * Stats writer module.
@@ -135,6 +145,25 @@ class StatsWriterPlugin {
       // Finish up.
       // eslint-disable-next-line max-statements
       .then((statsStr) => {
+        // Handle errors.
+        if (err) {
+          curCompiler.errors.push(err);
+          // eslint-disable-next-line promise/no-callback-in-promise
+          if (callback) { return void callback(err); }
+          throw err;
+        }
+
+        const filename = typeof this.opts.filename === "function"
+          ? this.opts.filename(curCompiler)
+          : this.opts.filename;
+
+        if (isReadableStream(statsStr)) {
+          const writeStream = fs.createWriteStream(path.join(stats.outputPath, filename));
+          statsStr.on("data", (chunk) => writeStream.write(chunk));
+          statsStr.on("end", () => writeStream.end());
+          return;
+        }
+
         // Create simple equivalent of RawSource from webpack-sources.
         const statsBuf = Buffer.from(statsStr || "", "utf-8");
         const source = curCompiler.webpack
@@ -149,18 +178,6 @@ class StatsWriterPlugin {
               return statsBuf.length;
             }
           };
-
-        // Handle errors.
-        if (err) {
-          curCompiler.errors.push(err);
-          // eslint-disable-next-line promise/no-callback-in-promise
-          if (callback) { return void callback(err); }
-          throw err;
-        }
-
-        const filename = typeof this.opts.filename === "function"
-          ? this.opts.filename(curCompiler)
-          : this.opts.filename;
 
         // Add to assets.
         if (curCompiler.emitAsset) {


### PR DESCRIPTION
Solves https://github.com/FormidableLabs/webpack-stats-plugin/issues/84

### Approach

Allow `transform()` to return a ReadableStream that may be useful to handle the big JSON (using https://github.com/Faleij/json-stream-stringify or similar).