### PR TITLE
README: transform option: show how the default looks

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,9 +165,19 @@ The `opts.filename` option can be a file name or path relative to `output.path` 
 
 **`transform`**
 
-By default, the retrieved stats object is `JSON.stringify`'ed but by supplying an alternate transform you can target _any_ output format. See [`test/scenarios/webpack5/webpack.config.js`](test/scenarios/webpack5/webpack.config.js) for various examples including Markdown output.
+By default, the retrieved stats object is `JSON.stringify`'ed:
+```javascript
+new StatsWriterPlugin({
+  transform(data) {
+    return JSON.stringify(data, null, 2);
+  }
+})
+```
+
+By supplying an alternate transform you can target _any_ output format. See [`test/scenarios/webpack5/webpack.config.js`](test/scenarios/webpack5/webpack.config.js) for various examples including Markdown output.
 
 - **Warning**: The output of `transform` should be a `String`, not an object. On Node `v4.x` if you return a real object in `transform`, then webpack will break with a `TypeError` (See [#8](https://github.com/FormidableLabs/webpack-stats-plugin/issues/8)). Just adding a simple `JSON.stringify()` around your object is usually what you need to solve any problems.
+
 
 **Internal notes**
 

--- a/README.md
+++ b/README.md
@@ -178,7 +178,6 @@ By supplying an alternate transform you can target _any_ output format. See [`te
 
 - **Warning**: The output of `transform` should be a `String`, not an object. On Node `v4.x` if you return a real object in `transform`, then webpack will break with a `TypeError` (See [#8](https://github.com/FormidableLabs/webpack-stats-plugin/issues/8)). Just adding a simple `JSON.stringify()` around your object is usually what you need to solve any problems.
 
-
 **Internal notes**
 
 In modern webpack, the plugin uses the [`processAssets`](https://webpack.js.org/api/compilation-hooks/#processassets) compilation hook if available when adding the stats object file to the overall compilation to write out along with all the other webpack-built assets. This is the [last possible place](https://github.com/webpack/webpack/blob/f2f998b58362d5edc9945a48f8245a3347ad007c/lib/Compilation.js#L2000-L2007) to hook in before the compilation is frozen in future webpack releases.


### PR DESCRIPTION
This PR possibly improves the documentation of the `transform` option by showing how the complete code for the default transform.