### PR TITLE
chore: update github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,42 +10,25 @@ on:
 
 jobs:
   build:
-
     runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:
         # TODO(68): Add `windows-latest` and support.
         os: [ubuntu-latest]
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [18.x]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-
-      # Note: Yarn root cache restore is slow (1:30) on Windows, so only do on Linux.
-      - name: Get Yarn cache directory
-        if: runner.os != 'Windows'
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - name: Use Yarn cache
-        if: runner.os != 'Windows'
-        uses: actions/cache@v2
-        id: yarn-cache
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: yarn-${{ runner.os }}-${{ matrix.node-version }}-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            yarn-${{ runner.os }}-${{ matrix.node-version }}-
-            yarn-${{ runner.os }}-
+          cache: "yarn"
 
       - name: Use node_modules cache
         id: node-modules-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: node_modules
           key: node-modules-${{ runner.os }}-${{ matrix.node-version }}-${{ hashFiles('./yarn.lock') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,7 @@ jobs:
 
       - name: Checks
         run: yarn run check
+        env:
+          # Webpack fails due to crypto enforcements in Node 17+
+          # See, e.g., https://github.com/webpack/webpack/issues/14532
+          NODE_OPTIONS: "--openssl-legacy-provider"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,20 +10,14 @@ on:
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
-
-    strategy:
-      matrix:
-        # TODO(68): Add `windows-latest` and support.
-        os: [ubuntu-latest]
-        node-version: [18.x]
+    runs-on: "ubuntu-latest"
 
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 18
           cache: "yarn"
 
       - name: Use node_modules cache
@@ -31,9 +25,8 @@ jobs:
         uses: actions/cache@v4
         with:
           path: node_modules
-          key: node-modules-${{ runner.os }}-${{ matrix.node-version }}-${{ hashFiles('./yarn.lock') }}
+          key: node-modules-${{ runner.os }}-${{ hashFiles('./yarn.lock') }}
           restore-keys: |
-            node-modules-${{ runner.os }}-${{ matrix.node-version }}-
             node-modules-${{ runner.os }}-
 
       - name: Project installation
@@ -47,7 +40,3 @@ jobs:
 
       - name: Checks
         run: yarn run check
-        env:
-          # Webpack fails due to crypto enforcements in Node 17+
-          # See, e.g., https://github.com/webpack/webpack/issues/14532
-          NODE_OPTIONS: ${{ matrix.node-version == '18.x' && '--openssl-legacy-provider' || '' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,8 +16,8 @@ jobs:
       packages: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 18
 

--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@
     <img alt="build status" src="https://github.com/FormidableLabs/webpack-stats-plugin/actions/workflows/ci.yml/badge.svg">
   </a>
   <a href="https://github.com/FormidableLabs/webpack-stats-plugin#maintenance-status">
-    <img alt="Maintenance Status" src="https://img.shields.io/badge/maintenance-active-green.svg" />
+    <img alt="Maintenance Status" src="https://img.shields.io/badge/maintenance-active-green.svg?color=brightgreen&style=flat" />
   </a>
   <a href="https://github.com/FormidableLabs/webpack-stats-plugin/blob/main/LICENSE.txt">
-  <img alt="license" src="https://img.shields.io/npm/l/webpack-stats-plugin"j>
+  <img alt="license" src="https://img.shields.io/npm/l/webpack-stats-plugin?color=brightgreen&style=flat">
   </a>
 </p>
 
@@ -218,11 +218,3 @@ In earlier webpack, the plugin uses the much later [`emit`](https://webpack.js.o
 ## Maintenance Status
 
 **Active:** NearForm is actively working on this project, and we expect to continue for work for the foreseeable future. Bug reports, feature requests and pull requests are welcome.
-
-[npm_img]: https://badge.fury.io/js/webpack-stats-plugin.svg
-[npm_site]: http://badge.fury.io/js/webpack-stats-plugin
-[actions_img]: https://github.com/FormidableLabs/webpack-stats-plugin/workflows/CI/badge.svg
-[actions_site]: https://github.com/FormidableLabs/webpack-stats-plugin/actions
-[lic_img]: https://img.shields.io/npm/l/webpack-stats-plugin.svg?color=brightgreen&style=flat
-[lic_site]: https://github.com/FormidableLabs/webpack-stats-plugin/blob/main/LICENSE.txt
-[maintenance_image]: https://img.shields.io/badge/maintenance-active-green.svg?color=brightgreen&style=flat

--- a/README.md
+++ b/README.md
@@ -1,9 +1,27 @@
-[![Webpack Stats Plugin — Formidable, We build the modern web](https://raw.githubusercontent.com/FormidableLabs/webpack-stats-plugin/master/webpack-stats-plugin-Hero.png)](https://formidable.com/open-source/)
+<a href="https://commerce.nearform.com/open-source/" target="_blank">
+  <img alt="Victory — Formidable, We build the modern web" src="https://oss.nearform.com/api/banner.svg?badge=Webpack%20Stats%20Plugin&bg=e8b25a" />
+</a>
 
-[![npm version][npm_img]][npm_site]
-[![Actions Status][actions_img]][actions_site]
-[![MIT license][lic_img]][lic_site]
-[![Maintenance Status][maintenance_image]](#maintenance-status)
+<br />
+<br />
+
+<p align="center">
+  <a href="https://npmjs.com/package/webpack-stats-plugin">
+    <img alt="weekly downloads" src="https://img.shields.io/npm/dw/webpack-stats-plugin">
+  </a>
+  <a href="https://npmjs.com/package/webpack-stats-plugin">
+    <img alt="current version" src="https://img.shields.io/npm/v/webpack-stats-plugin">
+  </a>
+  <a href="https://github.com/FormidableLabs/webpack-stats-plugin/actions">
+    <img alt="build status" src="https://github.com/FormidableLabs/webpack-stats-plugin/actions/workflows/ci.yml/badge.svg">
+  </a>
+  <a href="https://github.com/FormidableLabs/webpack-stats-plugin#maintenance-status">
+    <img alt="Maintenance Status" src="https://img.shields.io/badge/maintenance-active-green.svg" />
+  </a>
+  <a href="https://github.com/FormidableLabs/webpack-stats-plugin/blob/main/LICENSE.txt">
+  <img alt="license" src="https://img.shields.io/npm/l/webpack-stats-plugin"j>
+  </a>
+</p>
 
 This plugin will ingest the webpack [stats](https://webpack.js.org/configuration/stats/#stats) object, process / transform the object and write out to a file for further consumption.
 
@@ -199,7 +217,7 @@ In earlier webpack, the plugin uses the much later [`emit`](https://webpack.js.o
 
 ## Maintenance Status
 
-**Active:** Formidable is actively working on this project, and we expect to continue for work for the foreseeable future. Bug reports, feature requests and pull requests are welcome.
+**Active:** NearForm is actively working on this project, and we expect to continue for work for the foreseeable future. Bug reports, feature requests and pull requests are welcome.
 
 [npm_img]: https://badge.fury.io/js/webpack-stats-plugin.svg
 [npm_site]: http://badge.fury.io/js/webpack-stats-plugin

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <a href="https://commerce.nearform.com/open-source/" target="_blank">
-  <img alt="Victory — Formidable, We build the modern web" src="https://oss.nearform.com/api/banner.svg?badge=Webpack%20Stats%20Plugin&bg=e8b25a" />
+  <img alt="Webpack Stats Plugin" src="https://oss.nearform.com/api/banner.svg?badge=Webpack%20Stats%20Plugin&bg=e8b25a" />
 </a>
 
 <br />


### PR DESCRIPTION
### Description

Updated to the following actions versions:

- checkout@v4
- setup-node@v4

Replaced yarn cache setup that previously used `actions/cache` with `actions/setup-node`

Removed OS matrix, set runner to `ubuntu-latest` and node-version to `18`.

Additionally, updated README with NearForm banner/badges.

#### Type of Change

<!-- Please delete options that are not relevant (including this descriptive text). -->

- [X]  Adding or updating CI (Actions)
